### PR TITLE
Create temporary branch at local checkout in CI

### DIFF
--- a/meta/appveyor.yml
+++ b/meta/appveyor.yml
@@ -47,18 +47,17 @@ install:
       }
 
 build_script:
-  # we must check out the original branch locally, not the virtual merge
-  # by default cargo generate will check out master and there is no way to specify the virtual merge commit, only a branch
-  # so let's just pull it back to the branch we want to test (must be available locally for the later generate command to work)
-  - echo %APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH%
-  - git checkout %APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH%
+  # No matter what is currently checked out by the CI (master, other branch, PR merge commit),
+  # we create a temporary local branch from that point with a constant name, which we need for
+  # cargo generate.
+  - git branch current-ci-checkout
   - cd ..
   - ps: |
       if (Test-Path 'test-generation-in-ci/target') {
         Move-Item test-generation-in-ci/target target-cache;
         Remove-Item -path test-generation-in-ci -recurse
       }
-  - cargo generate --git cosmwasm-template --name test-generation-in-ci --branch %APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH%
+  - cargo generate --git cosmwasm-template --name test-generation-in-ci --branch current-ci-checkout
   - ps: |
       if (Test-Path 'target-cache') {
         Move-Item target-cache test-generation-in-ci/target


### PR DESCRIPTION
In the CI log of https://github.com/confio/cosmwasm-template/commit/f812a64b4a852b3c8b211967d9842f1b1877b71d we can see that `%APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH%` is not set for the master build.

Even for PR builds this variable does not contain what we want. We test the merge commit of _PR merged into current master branch_. Instead `APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH` contains the PR branch and does not respect changes that happened on master in the meantime.

Luckily, CI systems checkout exactly the commit we want. If we use the current commit and create a new local branch name, we can refer to this branch in `cargo generate`.